### PR TITLE
Separate routes to access logged sitter profile and sitter profile by id.

### DIFF
--- a/src/controllers/sitters.controllers.ts
+++ b/src/controllers/sitters.controllers.ts
@@ -23,6 +23,9 @@ const createSitter = async (req: Request, res: Response) => {
 };
 
 const getSitter = async (req: Request, res: Response) => {
+  // TODO: this is destructuring req.user but passing params!!
+  // correct it and make a separeted route to get sitter profile by id(user request)
+  // and another to get sitter profile by token(sitter request)
   const { user } = req;
   try {
     const sitter = await getSitterProfile(req.params.id as unknown as number);

--- a/src/controllers/sitters.controllers.ts
+++ b/src/controllers/sitters.controllers.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import {
   createSitterProfile,
-  getSitterProfile,
+  getSitterOwnProfile,
+  getOneSitter,
   getAllSitters,
   updateSitterProfile,
 } from '../services/sitter.services.js';
@@ -22,23 +23,31 @@ const createSitter = async (req: Request, res: Response) => {
   }
 };
 
-const getSitter = async (req: Request, res: Response) => {
-  // TODO: this is destructuring req.user but passing params!!
-  // correct it and make a separeted route to get sitter profile by id(user request)
-  // and another to get sitter profile by token(sitter request)
+const getSitterProfile = async (req: Request, res: Response) => {
   const { user } = req;
   try {
-    const sitter = await getSitterProfile(req.params.id as unknown as number);
+    const sitter = await getSitterOwnProfile(user);
     res.status(200).json({ status: 'success', data: sitter });
   } catch (err) {
     const error = err as Error;
-    res
-      .status(404)
-      .json({
-        status: 'error',
-        message: error.message || 'An error occurred',
-        user,
-      });
+    res.status(404).json({
+      status: 'error',
+      message: error.message || 'An error occurred',
+    });
+  }
+};
+
+const getSitter = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const sitter = await getOneSitter(+id);
+    res.status(200).json({ status: 'success', data: sitter });
+  } catch (err) {
+    const error = err as Error;
+    res.status(404).json({
+      status: 'error',
+      message: error.message || 'An error occurred',
+    });
   }
 };
 
@@ -73,4 +82,10 @@ const updateSitter = async (req: Request, res: Response) => {
   }
 };
 
-export default { createSitter, getSitter, getSitters, updateSitter };
+export default {
+  createSitter,
+  getSitterProfile,
+  getSitter,
+  getSitters,
+  updateSitter,
+};

--- a/src/routes/sitter.routes.ts
+++ b/src/routes/sitter.routes.ts
@@ -33,14 +33,28 @@ const router = Router();
  */
 router.get('/all', sitterController.getSitters);
 
+// /**
+//  * @swagger
+//  * /api/sitters/profile:
+//  *   get:
+//  *     summary: Get the authenticated sitter's profile
+//  *     tags: [Sitters]
+//  *     security:
+//  *       - bearerAuth: []
+//  *     responses:
+//  *       200:
+//  *         description: Sitter profile retrieved successfully
+//  *       401:
+//  *         description: Unauthorized
+//  */
+router.get('/profile', auth, sitterController.getSitterProfile);
+
 /**
  * @swagger
  * /api/sitters/{id}:
  *   get:
  *     summary: Get a sitter by ID
  *     tags: [Sitters]
- *     security:
- *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -55,8 +69,6 @@ router.get('/all', sitterController.getSitters);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Sitter'
- *       401:
- *         description: Unauthorized
  *       404:
  *         description: Sitter not found
  *         content:
@@ -64,7 +76,7 @@ router.get('/all', sitterController.getSitters);
  *             schema:
  *               $ref: '#/components/schemas/ErrorSitterResponse'
  */
-router.get('/:id', auth, sitterController.getSitter);
+router.get('/:id', sitterController.getSitter);
 
 /**
  * @swagger

--- a/src/routes/sitter.routes.ts
+++ b/src/routes/sitter.routes.ts
@@ -33,20 +33,20 @@ const router = Router();
  */
 router.get('/all', sitterController.getSitters);
 
-// /**
-//  * @swagger
-//  * /api/sitters/profile:
-//  *   get:
-//  *     summary: Get the authenticated sitter's profile
-//  *     tags: [Sitters]
-//  *     security:
-//  *       - bearerAuth: []
-//  *     responses:
-//  *       200:
-//  *         description: Sitter profile retrieved successfully
-//  *       401:
-//  *         description: Unauthorized
-//  */
+/**
+ * @swagger
+ * /api/sitters/profile:
+ *   get:
+ *     summary: Get the authenticated sitter's profile
+ *     tags: [Sitters]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Sitter profile retrieved successfully
+ *       401:
+ *         description: Unauthorized
+ */
 router.get('/profile', auth, sitterController.getSitterProfile);
 
 /**

--- a/src/services/sitter.services.ts
+++ b/src/services/sitter.services.ts
@@ -1,6 +1,7 @@
 import { AppDataSource } from '../config/database.js';
 import { Sitter } from '../entities/Sitter.js';
 import { User } from '../entities/User.js';
+import { removeSensitiveData } from '../utils/index.js';
 
 const sitterRepo = AppDataSource.getRepository(Sitter);
 
@@ -21,18 +22,11 @@ export const createSitterProfile = async (user: User, bio: string) => {
   return sitter;
 };
 
-export const getSitterProfile = async (userId: number) => {
-  // this is not working properly
-  // user 7 logged who is sitter 2 pass id 2 retrieves user 7 data, but sitter not found message
-  // user 7 logged who is sitter 2 pass id 1 retrieves sitter 1 who is user 1 too
-
-  // user 1 logged who is sitter 1 pass id 1 retrieves sitter 1 who is user 1 too
-  // user 1 logged who is sitter 1 pass id 2 retrieves user 7 data, but sitter not found message
-
+export const getSitterOwnProfile = async (user: User) => {
   const sitter = await sitterRepo.findOne({
     where: {
       user: {
-        id: userId,
+        id: user.id,
       },
     },
     relations: ['user'],
@@ -40,15 +34,31 @@ export const getSitterProfile = async (userId: number) => {
   if (!sitter) {
     throw new Error('Sitter profile not found');
   }
-  // TODO: remove password from the user
-  return sitter;
+  const result = removeSensitiveData(sitter.user);
+  return { ...sitter, user: result };
+};
+
+export const getOneSitter = async (id: number) => {
+  const sitter = await sitterRepo.findOne({
+    where: { id },
+    relations: ['user'],
+  });
+  if (!sitter) {
+    throw new Error('Sitter profile not found');
+  }
+  const result = removeSensitiveData(sitter.user);
+  return { ...sitter, user: result };
 };
 
 export const getAllSitters = async () => {
   const sitters = await sitterRepo.find({
     relations: ['user'],
   });
-  return sitters;
+  const filteredSitters = sitters.map(({ user, ...sitter }) => ({
+    ...sitter,
+    user: removeSensitiveData(user),
+  }));
+  return filteredSitters;
 };
 
 export const updateSitterProfile = async (

--- a/src/services/sitter.services.ts
+++ b/src/services/sitter.services.ts
@@ -22,6 +22,13 @@ export const createSitterProfile = async (user: User, bio: string) => {
 };
 
 export const getSitterProfile = async (userId: number) => {
+  // this is not working properly
+  // user 7 logged who is sitter 2 pass id 2 retrieves user 7 data, but sitter not found message
+  // user 7 logged who is sitter 2 pass id 1 retrieves sitter 1 who is user 1 too
+
+  // user 1 logged who is sitter 1 pass id 1 retrieves sitter 1 who is user 1 too
+  // user 1 logged who is sitter 1 pass id 2 retrieves user 7 data, but sitter not found message
+
   const sitter = await sitterRepo.findOne({
     where: {
       user: {
@@ -33,6 +40,7 @@ export const getSitterProfile = async (userId: number) => {
   if (!sitter) {
     throw new Error('Sitter profile not found');
   }
+  // TODO: remove password from the user
   return sitter;
 };
 

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -44,8 +44,7 @@ export const getUserProfile = async (user: any) => {
   if (!user) {
     throw { status: 404, message: 'User not found' };
   }
-  // TODO: remove password
-  return user;
+  return removeSensitiveData(user);
 };
 
 export const updateUser = async (

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -44,6 +44,7 @@ export const getUserProfile = async (user: any) => {
   if (!user) {
     throw { status: 404, message: 'User not found' };
   }
+  // TODO: remove password
   return user;
 };
 


### PR DESCRIPTION
This pull request introduces a distinct route for sitters to access their profiles when logged in, separate from the route users use to view a sitter's profile by sitter ID. Additionally, it ensures that user passwords are not returned in the responses. This PR also updates the Swagger configuration.